### PR TITLE
fix(docker): Correct port mapping in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
   back:
     build: ./backend
     ports:
-      - 5500:5000
+      - 5500:5500
     environment:
       - CHOKIDAR_USEPOLLING=true
     env_file:


### PR DESCRIPTION
### 🛠 Fix: Correct Docker Compose Port Mapping  

This PR fixes an issue where the backend service was incorrectly mapped (`5500:5000` instead of `5500:5500`). 