### PR TITLE
✨ feat(dashboard): Add a dashboard

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,72 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Settings } from "lucide-react";
+
 function Dashboard() {
-  return(
-    <h1>I'm the dashboard !</h1>
-  )
+  const [giftMode, setGiftMode] = useState<"classic" | "secret">("classic");
+  const navigate = useNavigate();
+
+  return (
+    <section className="w-full px-6 md:px-14 lg:px-20 xl:px-16 py-12">
+      <div className="flex border-b mb-8">
+        {/* Selection of a mode (classic or secret)*/}
+        <button
+          onClick={() => setGiftMode("classic")}
+          className={`mr-6 pb-1 text-lg font-medium cursor-pointer ${giftMode === "classic"
+            ? "border-b-2 border-[#D36567] text-gray-900"
+            : "text-gray-500"
+            }`}
+        >
+          Classique
+        </button>
+        <button
+          onClick={() => setGiftMode("secret")}
+          className={`pb-1 text-lg font-medium cursor-pointer ${giftMode === "secret"
+            ? "border-b-2 border-[#D36567] text-gray-900"
+            : "text-gray-500"
+            }`}
+        >
+          Secret
+        </button>
+      </div>
+
+      {/* If  "classic" mode is selected*/}
+      {giftMode === "classic" && (
+        <section className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-8 gap-12">
+          {/* Option + (to create a new group) */}
+          <Card className="bg-[#D36567] rounded-xl h-32 flex items-center justify-center cursor-pointer hover:opacity-90">
+            <CardContent className="text-white text-5xl font-bold">+</CardContent>
+          </Card>
+
+          {/* Other groups */}
+          {[
+            { title: "Amis", color: "from-[#FF8177] via-[#CF556C] to-[#B12A5B]", route: "/friends" },
+            { title: "Travail", color: "from-[#BAC8E0] to-[#6A85B6]", route: "/work" },
+            { title: "Famille", color: "from-[#8DDAD5] to-[#00CDAC]", route: "/family" },
+          ].map((card) => (
+            <Card
+              key={card.title}
+              className={`relative bg-gradient-to-br ${card.color} rounded-xl h-32 p-4 text-white flex-col justify-center items-center cursor-pointer hover:opacity-90`}
+              onClick={() => navigate(card.route)}
+            >
+              <Settings className="absolute top-2 right-2 w-5 h-5 opacity-80" />
+              <CardContent className="flex-1 text-center text-lg font-semibold mt-8">
+                {card.title}
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+      )}
+
+      {/* If  "secret" mode is selected*/}
+      {giftMode === "secret" && (
+        <section className="text-gray-500 text-center mt-10">
+          <p>Prochainement un mode "Secret Santa" à venir ! (dans la v12)</p>
+        </section>
+      )}
+    </section>
+  );
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Changes

This PR adds a new dashboard with two sections : `classique` and `secret`.

When the classic mode is selected, users can :

 - Choose a group from predefined options : `Amis`, `Famille`, or `Travail`.
 - Or create a new custom group by clicking the `+` button.