### PR TITLE
feat(dashboard): Improve inactive group card, add a tooltip and redir…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,7 +67,6 @@ function App() {
                 <Route path="/group" Component={Group} />
                 <Route path="/group/:id/settings" Component={GroupSettings} />
                 <Route path="/group-creation" Component={GroupCreation} />
-                <Route path="/group-settings" Component={GroupSettings} />
                 <Route path="/chat-select" Component={MobileChatSelect} />
                 <Route path="/wishlist" Component={Wishlist} />
               </Route>

--- a/frontend/src/api/group.ts
+++ b/frontend/src/api/group.ts
@@ -48,6 +48,20 @@ export const CREATE_GROUP = gql`
   }
 `;
 
+export const UPDATE_GROUP = gql`
+  mutation UpdateGroup($data: GroupUpdateInput!, $updateGroupId: ID!) {
+    updateGroup(data: $data, id: $updateGroupId) {
+      id
+      name
+      end_date
+      is_secret_santa
+      created_at
+      updated_at
+      is_active
+    }
+  }
+`;
+
 export const ADD_USERS_TO_GROUP = gql`
   mutation AddUsersToGroupByEmail($emails: [String!]!, $groupId: ID!) {
     addUsersToGroupByEmail(emails: $emails, groupId: $groupId) {

--- a/frontend/src/components/SecretGroupTab.tsx
+++ b/frontend/src/components/SecretGroupTab.tsx
@@ -1,15 +1,10 @@
-import { useQuery } from "@apollo/client";
 import { useNavigate } from "react-router-dom";
-import { Calendar, Gift } from "lucide-react";
-import { GET_USER_GROUPS } from "@/api/group";
-import { useAuth } from "@/hooks/useAuth";
+import { Gift } from "lucide-react";
 import {
   CreateGroupCard,
-  GroupCard,
-  LoadingState,
-  ErrorState,
   HowItWorksSection,
   GroupGrid,
+  GroupCardDisplay,
 } from "@/components/dashboard";
 
 interface Group {
@@ -26,30 +21,17 @@ interface Group {
   }[];
 }
 
-function SecretGroupTab() {
+interface SecretGroupTabProps {
+  groups: Group[];
+  user: any;
+  groupColors: string[];
+}
+
+function SecretGroupTab({ groups: secretSantaGroups, user, groupColors }: SecretGroupTabProps) {
   const navigate = useNavigate();
-  const { user } = useAuth();
 
-  const { data, loading, error } = useQuery(GET_USER_GROUPS, {
-    variables: { userId: user?.id },
-    skip: !user?.id,
-  });
-
-  if (loading) {
-    return <LoadingState message="Chargement de vos groupes Secret Santa..." />;
-  }
-
-  if (error) {
-    return (
-      <ErrorState
-        message="Erreur lors du chargement de vos groupes Secret Santa"
-        icon={Gift}
-      />
-    );
-  }
-
-  const secretSantaGroups =
-    data?.getUserGroups?.filter((group: Group) => group.is_secret_santa) || [];
+  // Sort Secret Santa groups: active ones first
+  const sortedSecretSantaGroups = [...secretSantaGroups].sort((a, b) => Number(b.is_active) - Number(a.is_active));
 
   const secretSantaSteps = [
     {
@@ -74,45 +56,7 @@ function SecretGroupTab() {
       {secretSantaGroups.length > 0 ? (
         <GroupGrid title="Vos groupes Secret Santa">
           <CreateGroupCard onClick={() => navigate("/group-creation")} />
-
-          {secretSantaGroups.map((group: Group) => (
-            <GroupCard
-              key={group.id}
-              title={group.name}
-              color="from-[#FF6B6B] via-[#FF8E53] to-[#FF6B35]"
-              route=""
-              id={group.id}
-              memberCount={group.users.length}
-              onSettingsClick={(e) => {
-                e.stopPropagation();
-                navigate(`/group/${group.id}/settings`);
-              }}
-            >
-              {/* Informations supplémentaires pour Secret Santa */}
-              <div className="text-center space-y-1">
-                {group.end_date && (
-                  <div className="flex items-center justify-center gap-1 text-xs opacity-90">
-                    <Calendar className="w-3 h-3" />
-                    <span>
-                      {new Date(group.end_date).toLocaleDateString("fr-FR")}
-                    </span>
-                  </div>
-                )}
-
-                <div className="flex items-center justify-center">
-                  <span
-                    className={`text-xs px-3 py-1 rounded-full font-medium ${
-                      group.is_active
-                        ? "bg-green-400/30 text-green-100"
-                        : "bg-yellow-400/30 text-yellow-100"
-                    }`}
-                  >
-                    {group.is_active ? "Actif" : "En attente"}
-                  </span>
-                </div>
-              </div>
-            </GroupCard>
-          ))}
+          <GroupCardDisplay groups={sortedSecretSantaGroups} user={user} groupColors={groupColors} />
         </GroupGrid>
       ) : (
         <HowItWorksSection

--- a/frontend/src/components/dashboard/GroupCard.tsx
+++ b/frontend/src/components/dashboard/GroupCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { Settings, Users } from "lucide-react";
+import { Users } from "lucide-react";
 import { Link } from "react-router-dom";
 
 interface GroupCardProps {
@@ -19,32 +19,12 @@ function GroupCard({
   route,
   id,
   memberCount,
-  onSettingsClick,
-  settingsRoute,
   children,
 }: GroupCardProps) {
   const cardContent = (
     <Card
       className={`group relative bg-gradient-to-br ${color} rounded-2xl h-48 flex flex-col cursor-pointer hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-2xl border-0 overflow-hidden`}
     >
-      {/* Bouton settings */}
-      <div className="absolute top-4 right-4 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300">
-        <div
-          className="w-8 h-8 bg-white/20 rounded-full flex items-center justify-center hover:bg-white/30 transition-colors duration-200"
-          onClick={
-            onSettingsClick ||
-            ((e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              if (settingsRoute) {
-                window.location.href = settingsRoute;
-              }
-            })
-          }
-        >
-          <Settings className="w-4 h-4 text-white" />
-        </div>
-      </div>
 
       <CardContent className="flex flex-col items-center justify-center text-white p-6 h-full">
         {/* Compteur du nombre de membres amélioré */}

--- a/frontend/src/components/dashboard/GroupCardDisplay.tsx
+++ b/frontend/src/components/dashboard/GroupCardDisplay.tsx
@@ -1,0 +1,121 @@
+import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import GroupCard from "./GroupCard";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface GroupCardDisplayProps {
+  groups: any[];
+  user: any;
+  groupColors: string[];
+}
+
+// Displays a list of group cards with conditional rendering for active and inactive groups
+export default function GroupCardDisplay({ groups, user, groupColors }: GroupCardDisplayProps) {
+  const navigate = useNavigate();
+  const [showTooltip, setShowTooltip] = useState<{ [key: string]: boolean }>({});
+
+  useEffect(() => {
+    if (!Object.values(showTooltip).some(Boolean)) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      Object.keys(showTooltip).forEach((groupId) => {
+        if (showTooltip[groupId]) {
+          if (!(event.target as HTMLElement).closest(`#inactive-group-card-${groupId}`)) {
+            setShowTooltip((prev) => ({ ...prev, [groupId]: false }));
+          }
+        }
+      });
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showTooltip]);
+
+  return (
+    <>
+      {groups.map((group, idx) => {
+        const isAdmin = group.users?.[0]?.id === user?.id; // ici l'admin est le 1er membre du groupe, à modifier plus tard
+        const inactiveClass = !group.is_active ? "opacity-50 bg-gray-200" : "";
+
+        // Active Group: normal card
+        if (group.is_active) {
+          return (
+            <GroupCard
+              key={group.id}
+              title={group.name}
+              color={groupColors[idx % groupColors.length]}
+              route={`/group/${group.id}/chat-window`}
+              settingsRoute={`/group/${group.id}/settings`}
+              id={group.id}
+              memberCount={group.users.length}
+            />
+          );
+        } else if (isAdmin) {
+          // Inactive group & user is admin: clickable card to settings
+          return (
+            <div
+              key={group.id}
+              style={{ cursor: "pointer" }}
+              className={inactiveClass}
+              onClick={() => navigate(`/group/${group.id}/settings`)}
+            >
+              <GroupCard
+                title={group.name}
+                color={groupColors[idx % groupColors.length]}
+                route=""
+                settingsRoute={`/group/${group.id}/settings`}
+                id={group.id}
+                memberCount={group.users.length}
+              >
+                <span className="text-xs px-3 py-1 rounded-full font-medium bg-red-500/80 text-white-100">
+                  En attente (admin)
+                </span>
+              </GroupCard>
+            </div>
+          );
+        } else {
+          // Inactive group & user is not admin: grayed card with tooltip
+          const cardId = `inactive-group-card-${group.id}`;
+          return (
+            <TooltipProvider key={group.id}>
+              <Tooltip open={!!showTooltip[group.id]}>
+                <TooltipTrigger asChild>
+                  <div
+                    id={cardId}
+                    className="opacity-50 bg-gray-200 cursor-not-allowed pointer-events-auto"
+                    onClick={e => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setShowTooltip(prev => ({ ...prev, [group.id]: !prev[group.id] }));
+                    }}
+                    tabIndex={0}
+                    role="button"
+                  >
+                    <GroupCard
+                      title={group.name}
+                      color={groupColors[idx % groupColors.length]}
+                      route=""
+                      settingsRoute={`/group/${group.id}/settings`}
+                      id={parseInt(group.id, 10)}
+                      memberCount={group.users.length}
+                    >
+                      <span className="text-xs px-3 py-1 rounded-full font-medium bg-yellow-500/80 text-yellow-900">
+                        En attente
+                      </span>
+                    </GroupCard>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Ce groupe est en attente d'acceptation de toutes les invitations du groupe, vous serez notifié lorsqu'il sera actif.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          );
+        }
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/index.tsx
+++ b/frontend/src/components/dashboard/index.tsx
@@ -1,6 +1,7 @@
-export { default as CreateGroupCard } from "./CreateGroupCard";
 export { default as GroupCard } from "./GroupCard";
+export { default as CreateGroupCard } from "./CreateGroupCard";
 export { default as LoadingState } from "./LoadingState";
 export { default as ErrorState } from "./ErrorState";
 export { default as HowItWorksSection } from "./HowItWorksSection";
 export { default as GroupGrid } from "./GroupGrid";
+export { default as GroupCardDisplay } from "./GroupCardDisplay";

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -146,3 +146,15 @@
     );
   }
 }
+
+@keyframes spin-once {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.spin-once {
+  transition: transform 0.5s;
+}
+.hover\:spin-once:hover {
+  animation: spin-once 0.5s linear 1;
+}

--- a/frontend/src/pages/ChatSelect.tsx
+++ b/frontend/src/pages/ChatSelect.tsx
@@ -1,4 +1,5 @@
-import { GoPlus } from "react-icons/go";
+import { Settings } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -63,6 +64,8 @@ const chats: Chat[] = [
 ];
 
 function ChatSelect() {
+  const navigate = useNavigate();
+  const groupId = 1; // À remplacer par le vrai ID du groupe
   return (
     <>
       <header className="pt-10 px-4 flex justify-between items-center">
@@ -70,10 +73,7 @@ function ChatSelect() {
           <BreadcrumbList className="flex flex-col items-start gap-0 leading-none">
             <div className="flex items-center gap-1">
               <BreadcrumbItem>
-                <BreadcrumbLink
-                  href="/"
-                  className="text-primary/60 uppercase hover:text-primary/80 transition-colors duration-200"
-                >
+                <BreadcrumbLink href="/dashboard" className="text-primary/60 uppercase hover:text-primary/80 transition-colors duration-200">
                   Mes groupes
                 </BreadcrumbLink>
               </BreadcrumbItem>
@@ -86,8 +86,11 @@ function ChatSelect() {
             </BreadcrumbItem>
           </BreadcrumbList>
         </Breadcrumb>
-        <button className="bg-primary rounded-full p-2 text-white shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200">
-          <GoPlus size={22} className="rounded-full" />
+        <button
+          className="bg-primary rounded-full p-2 text-white shadow-lg cursor-pointer hover:scale-110 hover:shadow-md"
+          onClick={() => navigate(`/group/${groupId}/settings`)}
+        >
+          <Settings size={25} className="rounded-full spin-once hover:spin-once" />
         </button>
       </header>
       <section className="px-4 flex flex-col gap-4 pt-10">

--- a/frontend/src/pages/GroupCreation.tsx
+++ b/frontend/src/pages/GroupCreation.tsx
@@ -176,12 +176,7 @@ export default function GroupCreation() {
           <Button onClick={handlePrev} disabled={currentStep === 0}>
             Précédent
           </Button>
-          <Button
-            onClick={
-              currentStep === steps.length - 1 ? () => onSubmit() : handleNext
-            }
-            className="cursor-pointer"
-          >
+          <Button onClick={currentStep === steps.length - 1 ? () => onSubmit() : handleNext} className="cursor-pointer">
             {currentStep === steps.length - 1 ? "Terminer" : "Suivant"}
           </Button>
         </div>

--- a/frontend/src/pages/GroupSettings.tsx
+++ b/frontend/src/pages/GroupSettings.tsx
@@ -24,7 +24,7 @@ import { HelpCircle } from "lucide-react";
 import { toast } from "sonner";
 import { useParams } from "react-router-dom";
 import { useQuery, useMutation } from "@apollo/client";
-import { GET_GROUP, REMOVE_USER_FROM_GROUP } from "@/api/group";
+import { GET_GROUP, REMOVE_USER_FROM_GROUP, UPDATE_GROUP } from "@/api/group";
 import { User } from "@/utils/types/user";
 
 export default function GroupSettings() {
@@ -32,9 +32,8 @@ export default function GroupSettings() {
   const { data, loading, error, refetch } = useQuery(GET_GROUP, {
     variables: { id },
   });
-
+  const [updateGroup] = useMutation(UPDATE_GROUP);
   const [removeUserFromGroup] = useMutation(REMOVE_USER_FROM_GROUP);
-
   const [groupName, setGroupName] = useState("");
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [isSecretSanta, setIsSecretSanta] = useState(false);
@@ -54,18 +53,26 @@ export default function GroupSettings() {
   if (error) return <div>Erreur lors du chargement du groupe</div>;
   if (!data?.group) return <div>Groupe non trouvé</div>;
 
-  const handleSubmit = () => {
-    const groupData = {
-      name: groupName,
-      end_date: endDate,
-      is_secret_santa: isSecretSanta,
-      is_active: isActive,
-    };
-
-    console.log("Groupe modifié :", groupData);
-    toast("Modifications enregistrées", {
-      description: "Les paramètres ont bien été mis à jour.",
-    });
+  const handleSubmit = async () => {
+    try {
+      await updateGroup({
+        variables: {
+          data: {
+            name: groupName,
+            end_date: endDate,
+            is_secret_santa: isSecretSanta,
+            is_active: isActive,
+          },
+          updateGroupId: id,
+        },
+      });
+      toast.success("Modifications enregistrées", {
+        description: "Les paramètres ont bien été mis à jour.",
+      });
+      refetch();
+    } catch (error) {
+      toast.error("Erreur lors de la modification du groupe ");
+    }
   };
 
   const removeMember = async (userId: number) => {


### PR DESCRIPTION
…ect admin to settings

 Lorsqu'on qu'un groupe est inactif, la card est disable (grisé) => avec éventuellement un tootip qui s'affiche si l'utilisateur cherche quand même à cliquer dessus "Ce groupe est en attente d'acceptation de toutes les invitations du groupe, vous serez notifier lorsqu'il sera actif"
Si c'est un groupe dont l'utilisateur est administrateur et qu'il est inactif :

 La card du groupe n'est pas disable et lorsqu'on clique dessus on est redirigé sur la page des group settings

 Déplacer l'engrenage de redirection page group setting à l'intérieur de la page de groupe, à la place du "+"